### PR TITLE
Adjust model class fields

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -2,6 +2,7 @@
 Test Factory to make fake objects for testing
 """
 
+from datetime import datetime
 import factory
 from service.models import Order
 
@@ -15,5 +16,5 @@ class OrderFactory(factory.Factory):
         model = Order
 
     id = factory.Sequence(lambda n: n)
-    name = factory.Faker("first_name")
     customer_id = factory.Sequence(lambda n: n)
+    created_at = factory.LazyFunction(datetime.now)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -65,24 +65,23 @@ class TestOrder(TestCase):
     #  T E S T   C A S E S
     ######################################################################
 
-    # Todo: Add your test cases here...
     def test_list_order(self):
         """It should list all Orders"""
-        Order = OrderFactory()
-        Order.create()
-        self.assertIsNotNone(Order.id)
-        found = Order.all()
-        self.assertEqual(len(found), 1)
-        data = Order.find(Order.id)
-        self.assertEqual(data.name, Order.name)
+        order = OrderFactory()
+        order.create()
+        self.assertIsNotNone(order.id)
+
+        orders_found = Order.all()
+        self.assertEqual(len(orders_found), 1)
+
+        order_found, = orders_found
+        self.assertEqual(order_found, order)
 
     def test_find_order(self):
         """It should find an Order by ID"""
-        order = Order(name="Test Order", customer_id=123)
+        order = OrderFactory()
         order.create()
 
         found = Order.find(order.id)
         self.assertIsNotNone(found)
-        self.assertEqual(found.id, order.id)
-        self.assertEqual(found.name, "Test Order")
-        self.assertEqual(found.customer_id, 123)
+        self.assertEqual(found, order)


### PR DESCRIPTION
This PR:
- Removes the `name` field from our `Order` and `OrderItem` models, as it isn't very necessary for orders and their items to have names (?)
- Adds a `created_at` field of type `datetime` (or the SQLAlchemy `DateTime`) to the `Order` model class. It's a feature addition for customers to know when they placed an order. The format of the datetime when serialized is in [ISO 8601 format](https://en.wikipedia.org/wiki/ISO_8601).
- Closes #37 