### PR TITLE
Implement Update Order Item

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -189,26 +189,54 @@ def create_item(order_id: int):
             f"Missing required fields: {', '.join(missing)}",
         )
 
+    data["order_id"] = order_id
+
     order_item = OrderItem()
     order_item.deserialize(data)
-    order_item.order_id = order_id
 
     order_item.create()
 
-    # TODO: Uncomment when get order item is implemented
-    # Return the location of the new Order
-    # location_url = url_for(
-    #     "get_item",  # to define : /orders/<int:order_id>/items/<int:item_id>
-    #     order_id=order_id,
-    #     item_id=order_item.id,
-    #     _external=True,
-    # )
-    location_url = "unknown"
+    location_url = url_for(
+        "get_order_item",  # defined : /orders/<int:order_id>/items/<int:item_id>
+        order_id=order_id,
+        order_item_id=order_item.id,
+        _external=True,
+    )
+
     return (
         jsonify(order_item.serialize()),
         status.HTTP_201_CREATED,
         {"Location": location_url},
     )
+
+
+######################################################################
+# GET A SINGLE ORDER ITEM
+######################################################################
+@app.get("/orders/<int:order_id>/items/<int:order_item_id>")
+def get_order_item(order_id: int, order_item_id: int):
+    """Get a specific OrderItem from an existing Order"""
+    app.logger.info(
+        "Request to get order_item [%d] from order [%d]", order_item_id, order_id
+    )
+
+    # Check if the order exists
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' was not found.",
+        )
+
+    # Check if the order_item exists and belongs to the correct order
+    order_item = OrderItem.find(order_item_id)
+    if not order_item or order_item.order_id != order_id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"OrderItem with id '{order_item_id}' was not found in order '{order_id}'.",
+        )
+
+    return jsonify(order_item.serialize()), status.HTTP_200_OK
 
 
 ######################################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -78,7 +78,7 @@ def create_order():
 ######################################################################
 # GET AN ORDER
 ######################################################################
-@app.get("/orders/<order_id>")
+@app.get("/orders/<int:order_id>")
 def get_order(order_id: int):
     """Get an Order"""
     order = Order.find(order_id)
@@ -90,7 +90,7 @@ def get_order(order_id: int):
 ######################################################################
 # UPDATE AN ORDER
 ######################################################################
-@app.put("/orders/<order_id>")
+@app.put("/orders/<int:order_id>")
 def update_order(order_id: int):
     """
     Update an Order
@@ -120,7 +120,7 @@ def update_order(order_id: int):
 ######################################################################
 # DELETE AN ORDER
 ######################################################################
-@app.delete("/orders/<order_id>")
+@app.delete("/orders/<int:order_id>")
 def delete_order(order_id: int):
     """
     Delete an Order
@@ -171,13 +171,12 @@ def list_orders():
 # CREATE A NEW ORDER ITEM
 ######################################################################
 @app.post("/orders/<int:order_id>/items")
-def create_item(order_id: int):
+def create_order_item(order_id: int):
     """Create an OrderItem and attach it to an existing Order"""
     app.logger.info("Request to create an OrderItem for order %d", order_id)
     check_content_type("application/json")
 
-    order = Order.find(order_id)
-    if not order:
+    if not Order.find(order_id):
         abort(status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found.")
 
     data = request.get_json()
@@ -190,14 +189,12 @@ def create_item(order_id: int):
         )
 
     data["order_id"] = order_id
-
     order_item = OrderItem()
     order_item.deserialize(data)
-
     order_item.create()
 
     location_url = url_for(
-        "get_order_item",  # defined : /orders/<int:order_id>/items/<int:item_id>
+        "get_order_item",  # defined: /orders/<int:order_id>/items/<int:item_id>
         order_id=order_id,
         order_item_id=order_item.id,
         _external=True,
@@ -236,6 +233,44 @@ def get_order_item(order_id: int, order_item_id: int):
             f"OrderItem with id '{order_item_id}' was not found in order '{order_id}'.",
         )
 
+    return jsonify(order_item.serialize()), status.HTTP_200_OK
+
+
+######################################################################
+# UPDATE AN ORDER ITEM
+######################################################################
+@app.put("/orders/<int:order_id>/items/<int:order_item_id>")
+def update_order_item(order_id: int, order_item_id: int):
+    """Update an OrderItem on an existing Order"""
+    app.logger.info(
+        "Request to update order_item [%d] from order [%d]", order_item_id, order_id
+    )
+
+    # Check if the order exists
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' was not found.",
+        )
+
+    # Check if the order_item exists and belongs to the correct order
+    order_item = OrderItem.find(order_item_id)
+    if not order_item or order_item.order_id != order_id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"OrderItem with id '{order_item_id}' was not found in order '{order_id}'.",
+        )
+
+    # Update the OrderItem with the request data
+    data = request.get_json()
+    app.logger.info("Updating OrderItem [%s] on Order [%s]", order_item_id, order_id)
+    order_item.deserialize(data)
+
+    # Save the new fields to the DB
+    order_item.update()
+
+    app.logger.info("OrderItem [%d] on Order [%s] updated.", order_item_id, order_id)
     return jsonify(order_item.serialize()), status.HTTP_200_OK
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -245,17 +245,25 @@ class TestOrder(TestCase):
 
         # Create an order item
         order_item = OrderItemFactory(order_id=order_id)
-        item_payload = {
+        payload = {
             "name": order_item.name,
             "product_id": order_item.product_id,
             "quantity": order_item.quantity,
         }
-        print("payload:", item_payload)
+        print("payload:", payload)
 
-        item_resp = self.client.post(f"{BASE_URL}/{order_id}/items", json=item_payload)
-        self.assertEqual(item_resp.status_code, status.HTTP_201_CREATED)
-        item_data = item_resp.get_json()
-        order_item_id = item_data["id"]
+        response = self.client.post(f"{BASE_URL}/{order_id}/items", json=payload)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        created_item = response.get_json()
+
+        # Check the created item
+        self.assertEqual(created_item["name"], payload["name"])
+        self.assertEqual(created_item["product_id"], payload["product_id"])
+        self.assertEqual(created_item["quantity"], payload["quantity"])
+        self.assertEqual(created_item["order_id"], order_id)
+
+        order_item_id = created_item["id"]
 
         # Retrieve the item
         get_url = f"{BASE_URL}/{order_id}/items/{order_item_id}"

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -191,6 +191,9 @@ class TestOrder(TestCase):
         data = response.get_json()
         self.assertEqual(len(data), 5)
 
+    # ----------------------------------------------------------
+    # TEST CREATE ORDER ITEM
+    # ----------------------------------------------------------
     def test_create_order_item(self):
         """It should create a new OrderItem inside an existing Order"""
 
@@ -207,8 +210,9 @@ class TestOrder(TestCase):
         }
 
         url = f"{BASE_URL}/{order_id}/items"
-        response = self.client.post(url, json=order_item.serialize())
+        response = self.client.post(url, json=payload)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
         created = response.get_json()
         self.assertEqual(created["order_id"], order_id)
         self.assertEqual(created["product_id"], payload["product_id"])
@@ -220,11 +224,46 @@ class TestOrder(TestCase):
         self.assertIsNotNone(location)
 
         # Check that the location header was correct
-        # TODO: Uncomment after get endpoint is defined
-        # response = self.client.get(location)
-        # self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = self.client.get(location)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.get_json()
         self.assertEqual(data["order_id"], order_id)
         self.assertEqual(data["product_id"], payload["product_id"])
         self.assertEqual(data["quantity"], payload["quantity"])
         self.assertEqual(data["name"], payload["name"])
+
+    # ----------------------------------------------------------
+    # TEST GET ORDER ITEM
+    # ----------------------------------------------------------
+    def test_get_order_item(self):
+        """It should Get an existing OrderItem"""
+        # Create an order
+        order = OrderFactory()
+        resp = self.client.post(BASE_URL, json=order.serialize())
+        self.assertEqual(resp.status_code, status.HTTP_201_CREATED)
+        order_id = resp.get_json()["id"]
+
+        # Create an order item
+        order_item = OrderItemFactory(order_id=order_id)
+        item_payload = {
+            "name": order_item.name,
+            "product_id": order_item.product_id,
+            "quantity": order_item.quantity,
+        }
+        print("payload:", item_payload)
+
+        item_resp = self.client.post(f"{BASE_URL}/{order_id}/items", json=item_payload)
+        self.assertEqual(item_resp.status_code, status.HTTP_201_CREATED)
+        item_data = item_resp.get_json()
+        order_item_id = item_data["id"]
+
+        # Retrieve the item
+        get_url = f"{BASE_URL}/{order_id}/items/{order_item_id}"
+        get_resp = self.client.get(get_url)
+        self.assertEqual(get_resp.status_code, status.HTTP_200_OK)
+        data = get_resp.get_json()
+        self.assertEqual(data["id"], order_item_id)
+        self.assertEqual(data["order_id"], order_id)
+        self.assertEqual(data["name"], order_item.name)
+        self.assertEqual(data["quantity"], order_item.quantity)
+        self.assertEqual(data["product_id"], order_item.product_id)


### PR DESCRIPTION
This PR:
- Is based on [kevin/get_order_item](https://github.com/CSCI-GA-2820-SU25-001/orders/tree/kevin/get_order_item) because Update is easier to implement when Get exists
- Adds the `int:` type specifier back to the Flask paths (it seems Flask does not use type annotations)
- Implements the Update Order Item endpoint with tests
- Closes #26 