### PR TITLE
Implement Delete Order Items

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -322,7 +322,16 @@ def delete_order_item(order_id: int, order_item_id: int):
 
     # Check if the item exists and belongs to the correct order
     order_item = OrderItem.find(order_item_id)
-    if not order_item or order_item.order_id != order_id:
+    # If item doesn't exist at all → 204
+    if not order_item:
+        app.logger.info(
+            "OrderItem [%d] not found. Nothing to delete, returning 204.",
+            order_item_id,
+        )
+        return {}, status.HTTP_204_NO_CONTENT
+
+    # Item exists but doesn't belong to the given order → 404
+    if order_item.order_id != order_id:
         abort(
             status.HTTP_404_NOT_FOUND,
             f"OrderItem with id '{order_item_id}' was not found in order '{order_id}'.",

--- a/service/routes.py
+++ b/service/routes.py
@@ -303,6 +303,37 @@ def list_order_items(order_id: int):
 
 
 ######################################################################
+# DELETE AN ORDER ITEM
+######################################################################
+@app.delete("/orders/<int:order_id>/items/<int:order_item_id>")
+def delete_order_item(order_id: int, order_item_id: int):
+    """Delete a specific OrderItem from an existing Order"""
+    app.logger.info(
+        "Request to delete order_item [%d] from order [%d]", order_item_id, order_id
+    )
+
+    # Check if the order exists
+    order = Order.find(order_id)
+    if not order:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"Order with id '{order_id}' was not found.",
+        )
+
+    # Check if the item exists and belongs to the correct order
+    order_item = OrderItem.find(order_item_id)
+    if not order_item or order_item.order_id != order_id:
+        abort(
+            status.HTTP_404_NOT_FOUND,
+            f"OrderItem with id '{order_item_id}' was not found in order '{order_id}'.",
+        )
+
+    order_item.delete()
+    app.logger.info("OrderItem [%d] from Order [%d] deleted.", order_item_id, order_id)
+    return {}, status.HTTP_204_NO_CONTENT
+
+
+######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -93,9 +93,7 @@ class TestOrder(TestCase):
         items = []
         for _ in range(count):
             item = OrderItemFactory()
-            response = self.client.post(
-                f"{BASE_URL}/{order_id}/items", json=item.serialize()
-            )
+            response = self.client.post(f"{BASE_URL}/{order_id}/items", json=item.serialize())
             self.assertEqual(
                 response.status_code,
                 status.HTTP_201_CREATED,


### PR DESCRIPTION
finished deleting order item, which is different from order deleting
It does not allow deleting non-exist order item.

- Added delete order item endpoint to service/routes.py for DELETE /orders/<order_id>/items/<order_item_id>
- Added two test cases in test_routes.py:

1. test_delete_order_item to verify successful deletion
2. test_delete_nonexistent_order_item to verify 404 for missing items

- Confirmed that deleted items are no longer retrievable via GET

Closes #23 