### PR TITLE
Remove `name` field from models

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -27,19 +27,15 @@ class Order(db.Model):
     # Table Schema
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(63))
     customer_id = db.Column(db.Integer)
     # maybe store any promotions used on this order?
-
-    # def __repr__(self):
-    #     return f"<Order name='{self.name}' id={self.id} customer_id={self.customer_id}>"
 
     def create(self):
         """
         Creates an order in the database
         """
         logger.info("Creating %s", self)
-        self.id = None  # pylint: disable=invalid-name
+        self.id = None
         try:
             db.session.add(self)
             db.session.commit()
@@ -73,12 +69,11 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id, "name": self.name, "customer_id": self.customer_id}
+        return {"id": self.id, "customer_id": self.customer_id}
 
     def deserialize(self, data: dict[str, Any]):
         """Deserializes an order from a dictionary"""
         try:
-            self.name = data["name"]
             self.customer_id = data["customer_id"]
         except KeyError as error:
             raise DataValidationError(
@@ -118,23 +113,16 @@ class OrderItem(db.Model):
     # Table Schema
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
-    name = db.Column(db.String(63))
     quantity = db.Column(db.Integer)
     order_id = db.Column(db.Integer)
     product_id = db.Column(db.Integer)
-
-    # def __repr__(self):
-    #     return (
-    #         f"<OrderItem name='{self.name}' id={self.id} quantity={self.quantity} "
-    #         f"order_id={self.order_id} product_id={self.product_id}>"
-    #     )
 
     def create(self):
         """
         Creates an order item in the database
         """
         logger.info("Creating %s", self)
-        self.id = None  # pylint: disable=invalid-name
+        self.id = None
         try:
             db.session.add(self)
             db.session.commit()
@@ -170,7 +158,6 @@ class OrderItem(db.Model):
         """Serializes an order item into a dictionary"""
         return {
             "id": self.id,
-            "name": self.name,
             "quantity": self.quantity,
             "order_id": self.order_id,
             "product_id": self.product_id,
@@ -184,12 +171,9 @@ class OrderItem(db.Model):
             data (dict): A dictionary containing the order data
         """
         try:
-            self.name = data["name"]
-            self.quantity = data["quantity"]
             self.order_id = data["order_id"]
+            self.quantity = data["quantity"]
             self.product_id = data["product_id"]
-        except AttributeError as error:
-            raise DataValidationError("Invalid attribute: " + error.args[0]) from error
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Order: missing " + error.args[0]
@@ -215,16 +199,6 @@ class OrderItem(db.Model):
         """Finds an order item by it's ID"""
         logger.info("Processing lookup for id %s ...", by_id)
         return cls.query.session.get(cls, by_id)
-
-    @classmethod
-    def find_by_name(cls, name: str):
-        """Returns all order items with the given name
-
-        Args:
-            name (string): the name of the order items you want to match
-        """
-        logger.info("Processing name query for %s ...", name)
-        return cls.query.filter(cls.name == name)
 
     @classmethod
     def find_by_order_id(cls, order_id: Any):

--- a/service/routes.py
+++ b/service/routes.py
@@ -177,15 +177,7 @@ def create_order_item(order_id: int):
     if not order:
         abort(status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found.")
 
-    # Verify required fields exist
     data = request.get_json()
-    required = {"name", "product_id", "quantity"}
-    missing = required - data.keys()
-    if missing:
-        abort(
-            status.HTTP_400_BAD_REQUEST,
-            f"Missing required fields: {', '.join(missing)}",
-        )
 
     # Insert the Order ID into the payload for OrderItem
     # Otherwise, OrderItem.deserialize() will error with KeyError

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -14,7 +14,6 @@ class OrderFactory(factory.Factory):
 
         model = Order
 
-    name = factory.Faker("first_name")
     customer_id = factory.Sequence(lambda n: n)
 
 
@@ -26,7 +25,6 @@ class OrderItemFactory(factory.Factory):
 
         model = OrderItem
 
-    name = factory.Faker("first_name")
     order_id = factory.Sequence(lambda n: n)
     product_id = factory.Sequence(lambda n: n)
     quantity = factory.Faker("pyint", min_value=1, max_value=10)


### PR DESCRIPTION
This PR:
- Removes the `name` field from both our models, as it has no significant purpose
- Closes #71 
- Increases test coverage to 97.55% (the remaining missing lines aren't our code)