### PR TITLE
Add Order-OrderItem relationship with cascade delete

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -46,6 +46,8 @@ class Order(db.Model):
         self.id = None
         try:
             db.session.add(self)
+            # The order_items will be automatically saved due to the relationship
+            # with cascade="all, delete-orphan" option
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/service/models.py
+++ b/service/models.py
@@ -194,16 +194,18 @@ class OrderItem(db.Model):
             data (dict): A dictionary containing the order data
         """
         try:
-            self.order_id = data["order_id"]
+            # order_id is optional - can be set through relationship
+            if "order_id" in data:
+                self.order_id = data["order_id"]
             self.quantity = data["quantity"]
             self.product_id = data["product_id"]
         except KeyError as error:
             raise DataValidationError(
-                "Invalid Order: missing " + error.args[0]
+                "Invalid OrderItem: missing " + error.args[0]
             ) from error
         except TypeError as error:
             raise DataValidationError(
-                "Invalid Order: body of request contained bad or no data " + str(error)
+                "Invalid OrderItem: body of request contained bad or no data " + str(error)
             ) from error
         return self
 

--- a/service/models.py
+++ b/service/models.py
@@ -34,6 +34,9 @@ class Order(db.Model):
     customer_id = db.Column(db.Integer)
     status = db.Column(db.String(16), nullable=False, default="placed")
     # maybe store any promotions used on this order?
+    
+    # Relationship to OrderItem with cascade delete
+    order_items = db.relationship("OrderItem", backref="order", cascade="all, delete-orphan")
 
     def create(self):
         """
@@ -74,7 +77,12 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id, "customer_id": self.customer_id, "status": self.status}
+        return {
+            "id": self.id, 
+            "customer_id": self.customer_id, 
+            "status": self.status,
+            "order_items": [item.serialize() for item in self.order_items]
+        }
 
     def deserialize(self, data: dict[str, Any]):
         """
@@ -129,7 +137,7 @@ class OrderItem(db.Model):
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
     quantity = db.Column(db.Integer)
-    order_id = db.Column(db.Integer)
+    order_id = db.Column(db.Integer, db.ForeignKey("Order.id"), nullable=False)
     product_id = db.Column(db.Integer)
 
     def create(self):

--- a/service/models.py
+++ b/service/models.py
@@ -34,9 +34,11 @@ class Order(db.Model):
     customer_id = db.Column(db.Integer)
     status = db.Column(db.String(16), nullable=False, default="placed")
     # maybe store any promotions used on this order?
-    
+
     # Relationship to OrderItem with cascade delete
-    order_items = db.relationship("OrderItem", backref="order", cascade="all, delete-orphan", passive_deletes=True)
+    order_items = db.relationship(
+        "OrderItem", backref="order", cascade="all, delete-orphan", passive_deletes=True
+    )
 
     def create(self):
         """
@@ -80,10 +82,10 @@ class Order(db.Model):
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
         return {
-            "id": self.id, 
-            "customer_id": self.customer_id, 
+            "id": self.id,
+            "customer_id": self.customer_id,
             "status": self.status,
-            "order_items": [item.serialize() for item in self.order_items]
+            "order_items": [item.serialize() for item in self.order_items],
         }
 
     def deserialize(self, data: dict[str, Any]):
@@ -98,19 +100,19 @@ class Order(db.Model):
                 raise DataValidationError(f"Invalid status '{status}'")
 
             self.status = status
-            
+
             # Handle order_items if present in the data
             if "order_items" in data:
                 # Clear existing order_items first
                 self.order_items.clear()
-                
+
                 # Add new order_items
                 for item_data in data["order_items"]:
                     order_item = OrderItem()
                     order_item.deserialize(item_data)
                     # The order_id will be set automatically due to the relationship
                     self.order_items.append(order_item)
-                    
+
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Order: missing " + error.args[0]
@@ -152,7 +154,9 @@ class OrderItem(db.Model):
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
     quantity = db.Column(db.Integer)
-    order_id = db.Column(db.Integer, db.ForeignKey("Order.id", ondelete="CASCADE"), nullable=False)
+    order_id = db.Column(
+        db.Integer, db.ForeignKey("Order.id", ondelete="CASCADE"), nullable=False
+    )
     product_id = db.Column(db.Integer)
 
     def create(self):
@@ -220,7 +224,8 @@ class OrderItem(db.Model):
             ) from error
         except TypeError as error:
             raise DataValidationError(
-                "Invalid OrderItem: body of request contained bad or no data " + str(error)
+                "Invalid OrderItem: body of request contained bad or no data "
+                + str(error)
             ) from error
         return self
 

--- a/service/models.py
+++ b/service/models.py
@@ -13,6 +13,9 @@ logger = logging.getLogger("flask.app")
 # Create the SQLAlchemy object to be initialized later in init_db()
 db = SQLAlchemy()
 
+ALLOWED_STATUS = {"placed", "shipped", "returned", "canceled"}
+DEFAULT_STATUS = "placed"
+
 
 class DataValidationError(Exception):
     """Used for an data validation errors when deserializing"""
@@ -23,11 +26,13 @@ class Order(db.Model):
     Class that represents an order
     """
 
+    __tablename__ = "Order"
     ##################################################
     # Table Schema
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
+    status = db.Column(db.String(16), nullable=False, default="placed")
     # maybe store any promotions used on this order?
 
     def create(self):
@@ -69,16 +74,25 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id, "customer_id": self.customer_id}
+        return {"id": self.id, "customer_id": self.customer_id, "status": self.status}
 
     def deserialize(self, data: dict[str, Any]):
-        """Deserializes an order from a dictionary"""
+        """
+        Deserializes an order from a dictionary
+        """
         try:
             self.customer_id = data["customer_id"]
+            status = str(data.get("status", self.status or DEFAULT_STATUS)).lower()
+
+            if status not in ALLOWED_STATUS:
+                raise DataValidationError(f"Invalid status '{status}'")
+
+            self.status = status
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Order: missing " + error.args[0]
             ) from error
+
         return self
 
     ##################################################
@@ -109,6 +123,7 @@ class OrderItem(db.Model):
     Class that represents an order item
     """
 
+    __tablename__ = "OrderItem"
     ##################################################
     # Table Schema
     ##################################################

--- a/service/models.py
+++ b/service/models.py
@@ -36,7 +36,7 @@ class Order(db.Model):
     # maybe store any promotions used on this order?
     
     # Relationship to OrderItem with cascade delete
-    order_items = db.relationship("OrderItem", backref="order", cascade="all, delete-orphan")
+    order_items = db.relationship("OrderItem", backref="order", cascade="all, delete-orphan", passive_deletes=True)
 
     def create(self):
         """
@@ -152,7 +152,7 @@ class OrderItem(db.Model):
     ##################################################
     id = db.Column(db.Integer, primary_key=True)
     quantity = db.Column(db.Integer)
-    order_id = db.Column(db.Integer, db.ForeignKey("Order.id"), nullable=False)
+    order_id = db.Column(db.Integer, db.ForeignKey("Order.id", ondelete="CASCADE"), nullable=False)
     product_id = db.Column(db.Integer)
 
     def create(self):

--- a/service/models.py
+++ b/service/models.py
@@ -96,6 +96,19 @@ class Order(db.Model):
                 raise DataValidationError(f"Invalid status '{status}'")
 
             self.status = status
+            
+            # Handle order_items if present in the data
+            if "order_items" in data:
+                # Clear existing order_items first
+                self.order_items.clear()
+                
+                # Add new order_items
+                for item_data in data["order_items"]:
+                    order_item = OrderItem()
+                    order_item.deserialize(item_data)
+                    # The order_id will be set automatically due to the relationship
+                    self.order_items.append(order_item)
+                    
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Order: missing " + error.args[0]

--- a/service/models.py
+++ b/service/models.py
@@ -101,7 +101,9 @@ class Order(db.Model):
         try:
             self.customer_id = data["customer_id"]
             status = str(data.get("status", self.status or DEFAULT_STATUS)).lower()
-            self.created_at = data["created_at"]
+            # Only update created_at if it's provided in the data
+            if "created_at" in data:
+                self.created_at = data["created_at"]
             if status not in ALLOWED_STATUS:
                 raise DataValidationError(f"Invalid status '{status}'")
 

--- a/service/routes.py
+++ b/service/routes.py
@@ -277,6 +277,7 @@ def update_order_item(order_id: int, order_item_id: int):
     app.logger.info(
         "Request to update order_item [%d] from order [%d]", order_item_id, order_id
     )
+    check_content_type("application/json")
 
     # Check if the order exists
     order = Order.find(order_id)
@@ -297,6 +298,12 @@ def update_order_item(order_id: int, order_item_id: int):
     # Update the OrderItem with the request data
     data = request.get_json()
     app.logger.info("Updating OrderItem [%s] on Order [%s]", order_item_id, order_id)
+    
+    # Prevent order_id from being modified during update
+    if "order_id" in data:
+        data.pop("order_id")
+        app.logger.info("Removed order_id from update data to prevent modification")
+    
     order_item.deserialize(data)
 
     # Save the new fields to the DB

--- a/service/routes.py
+++ b/service/routes.py
@@ -111,9 +111,9 @@ def get_order(order_id: int):
             ),
             200,
         )
-    else:
-        # Default: return full order with order_items
-        return jsonify(order.serialize()), 200
+
+    # Default: return full order with order_items
+    return jsonify(order.serialize()), 200
 
 
 ######################################################################

--- a/service/routes.py
+++ b/service/routes.py
@@ -216,7 +216,7 @@ def create_order_item(order_id: int):
     data = request.get_json()
 
     # Insert the Order ID into the payload for OrderItem
-    # Otherwise, OrderItem.deserialize() will error with KeyError
+    # Now, OrderItem.deserialize() wont error with KeyError
     data["order_id"] = order_id
 
     # Create the order item in the DB

--- a/service/routes.py
+++ b/service/routes.py
@@ -95,17 +95,22 @@ def get_order(order_id: int):
     order = Order.find(order_id)
     if not order:
         abort(status.HTTP_404_NOT_FOUND, f"Order with id '{order_id}' was not found.")
-    
+
     # Check if only basic order info should be returned (use -o flag)
     only_order = request.args.get("o", "false").lower() == "true"
-    
+
     if only_order:
         # Return basic order info without order_items
-        return jsonify({
-            "id": order.id,
-            "customer_id": order.customer_id,
-            "status": order.status
-        }), 200
+        return (
+            jsonify(
+                {
+                    "id": order.id,
+                    "customer_id": order.customer_id,
+                    "status": order.status,
+                }
+            ),
+            200,
+        )
     else:
         # Default: return full order with order_items
         return jsonify(order.serialize()), 200
@@ -186,15 +191,14 @@ def list_orders():
     # Serialize orders with or without order_items based on query parameter
     if only_order:
         # Return basic order info without order_items
-        results = [{
-            "id": order.id,
-            "customer_id": order.customer_id,
-            "status": order.status
-        } for order in orders]
+        results = [
+            {"id": order.id, "customer_id": order.customer_id, "status": order.status}
+            for order in orders
+        ]
     else:
         # Default: return full orders with order_items
         results = [order.serialize() for order in orders]
-    
+
     app.logger.info("Returning %d orders", len(results))
     return jsonify(results), status.HTTP_200_OK
 
@@ -298,12 +302,12 @@ def update_order_item(order_id: int, order_item_id: int):
     # Update the OrderItem with the request data
     data = request.get_json()
     app.logger.info("Updating OrderItem [%s] on Order [%s]", order_item_id, order_id)
-    
+
     # Prevent order_id from being modified during update
     if "order_id" in data:
         data.pop("order_id")
         app.logger.info("Removed order_id from update data to prevent modification")
-    
+
     order_item.deserialize(data)
 
     # Save the new fields to the DB

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,6 +1,7 @@
 """
 Test Factory to make fake objects for testing
 """
+
 from datetime import datetime, UTC
 import factory
 from service.models import Order, OrderItem
@@ -40,7 +41,7 @@ class OrderItemFactory(factory.Factory):
     quantity = factory.Faker("pyint", min_value=1, max_value=10)
 
     @factory.post_generation
-    def set_order_id(obj, create, extracted, **kwargs):
-        """Set the order_id after the order is created"""
-        if obj.order:
-            obj.order_id = obj.order.id
+    def set_order_id(self, _create, _extracted, **_kwargs):
+        """Set the order_id after the order is created."""
+        if self.order:
+            self.order_id = self.order.id

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -28,6 +28,7 @@ class OrderItemFactory(factory.Factory):
 
         model = OrderItem
 
-    order_id = factory.Sequence(lambda n: n)
+    # Create a new Order by default to satisfy foreign key constraint
+    order_id = factory.LazyFunction(lambda: OrderFactory.create().id)
     product_id = factory.Sequence(lambda n: n)
     quantity = factory.Faker("pyint", min_value=1, max_value=10)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -28,7 +28,13 @@ class OrderItemFactory(factory.Factory):
 
         model = OrderItem
 
-    # Create a new Order by default to satisfy foreign key constraint
-    order_id = factory.LazyFunction(lambda: OrderFactory.create().id)
+    # Use SubFactory to create related Order object
+    order = factory.SubFactory(OrderFactory)
     product_id = factory.Sequence(lambda n: n)
     quantity = factory.Faker("pyint", min_value=1, max_value=10)
+    
+    @factory.post_generation
+    def set_order_id(obj, create, extracted, **kwargs):
+        """Set the order_id after the order is created"""
+        if obj.order:
+            obj.order_id = obj.order.id

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -32,7 +32,7 @@ class OrderItemFactory(factory.Factory):
     order = factory.SubFactory(OrderFactory)
     product_id = factory.Sequence(lambda n: n)
     quantity = factory.Faker("pyint", min_value=1, max_value=10)
-    
+
     @factory.post_generation
     def set_order_id(obj, create, extracted, **kwargs):
         """Set the order_id after the order is created"""

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -5,6 +5,8 @@ Test Factory to make fake objects for testing
 import factory
 from service.models import Order, OrderItem
 
+STATUS_CHOICES = ["placed", "shipped", "returned", "canceled"]
+
 
 class OrderFactory(factory.Factory):
     """Creates fake orders"""
@@ -15,6 +17,7 @@ class OrderFactory(factory.Factory):
         model = Order
 
     customer_id = factory.Sequence(lambda n: n)
+    status = factory.Faker("random_element", elements=STATUS_CHOICES)
 
 
 class OrderItemFactory(factory.Factory):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -41,7 +41,9 @@ class OrderItemFactory(factory.Factory):
     quantity = factory.Faker("pyint", min_value=1, max_value=10)
 
     @factory.post_generation
-    def set_order_id(self, _create, _extracted, **_kwargs):
+    def set_order_id(
+        self, _create, _extracted, **_kwargs
+    ):  # pylint: disable=attribute-defined-outside-init
         """Set the order_id after the order is created."""
         if self.order:
             self.order_id = self.order.id

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 ######################################################################
 
+
 """
-Test cases for Pet Model
+Test cases for Order Model
 """
 
 # pylint: disable=duplicate-code
@@ -275,3 +276,43 @@ class TestOrderItem(TestCase):
         self.assertEqual(item_found.quantity, item.quantity)
         self.assertEqual(item_found.order_id, item.order_id)
         self.assertEqual(item_found.product_id, item.product_id)
+
+    # -----------------------------------------------------------------
+    # STATUS FIELD TESTS
+    # -----------------------------------------------------------------
+
+    def test_default_status_is_placed(self):
+        """It should set status to 'placed' when none is supplied"""
+        order = Order(customer_id=1)
+        order.create()
+        self.assertEqual(order.status, "placed")
+
+        found = Order.find(order.id)
+        self.assertEqual(found.status, "placed")
+
+    def test_create_with_valid_status(self):
+        """It should create an Order with an explicit valid status"""
+        order = OrderFactory(status="shipped")
+        order.create()
+
+        found = Order.find(order.id)
+        self.assertEqual(found.status, "shipped")
+
+    def test_update_status(self):
+        """It should update an Order's status"""
+        order = OrderFactory(status="placed")
+        order.create()
+
+        # simulate deserialization from API payload
+        order.deserialize({"customer_id": order.customer_id, "status": "canceled"})
+        order.update()
+
+        found = Order.find(order.id)
+        self.assertEqual(found.status, "canceled")
+
+    def test_invalid_status_raises(self):
+        """It should raise DataValidationError when status is invalid"""
+        bad = OrderFactory().serialize()
+        bad["status"] = "invalid_status"
+
+        self.assertRaises(DataValidationError, lambda: Order().deserialize(bad))

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -56,7 +56,9 @@ class TestOrder(TestCase):
 
     def setUp(self):
         """This runs before each test"""
-        db.session.query(Order).delete()  # clean up the last tests
+        # Clean up OrderItems first due to foreign key constraint
+        db.session.query(OrderItem).delete()
+        db.session.query(Order).delete()
         db.session.commit()
 
     def tearDown(self):
@@ -157,7 +159,9 @@ class TestOrderItem(TestCase):
 
     def setUp(self):
         """This runs before each test"""
-        db.session.query(OrderItem).delete()  # clean up the last tests
+        # Clean up both OrderItems and Orders to avoid foreign key issues
+        db.session.query(OrderItem).delete()
+        db.session.query(Order).delete()
         db.session.commit()
 
     def tearDown(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -310,7 +310,13 @@ class TestOrderItem(TestCase):
         order.create()
 
         # simulate deserialization from API payload
-        order.deserialize({"customer_id": order.customer_id, "status": "canceled", "created_at": order.created_at})
+        order.deserialize(
+            {
+                "customer_id": order.customer_id,
+                "status": "canceled",
+                "created_at": order.created_at,
+            }
+        )
         order.update()
 
         found = Order.find(order.id)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -375,9 +375,10 @@ class TestOrder(TestCase):
 
         # Update the OrderItem object received with new values
         item_data = response.get_json()
-        item_data["order_id"] = -1
-        item_data["quantity"] = -1
-        item_data["product_id"] = -1
+        original_order_id = item_data["order_id"]
+        item_data["order_id"] = -1  # This should be ignored by the API
+        item_data["quantity"] = 99
+        item_data["product_id"] = 123
 
         # Call the Update Order Item API endpoint
         item_id = item_data["id"]
@@ -387,10 +388,12 @@ class TestOrder(TestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         # Verify that the OrderItem was updated
-        updated_order = response.get_json()
-        self.assertEqual(updated_order["order_id"], -1)
-        self.assertEqual(updated_order["quantity"], -1)
-        self.assertEqual(updated_order["product_id"], -1)
+        updated_item = response.get_json()
+        # order_id should remain unchanged (not be updated to -1)
+        self.assertEqual(updated_item["order_id"], original_order_id)
+        # Other fields should be updated
+        self.assertEqual(updated_item["quantity"], 99)
+        self.assertEqual(updated_item["product_id"], 123)
 
     def test_update_order_item_order_not_found(self):
         """It should return 404 when updating an OrderItem in a non-existing Order"""

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -201,7 +201,7 @@ class TestOrder(TestCase):
         update_data = {
             "id": new_order["id"],
             "customer_id": -1,
-            "status": new_order["status"]
+            "status": new_order["status"],
         }
         response = self.client.put(f"{BASE_URL}/{new_order['id']}", json=update_data)
         self.assertEqual(response.status_code, status.HTTP_200_OK)


### PR DESCRIPTION
Made the following changes:

• Added **foreign key relationship** between Order and OrderItem models
• Added **cascade delete** functionality (`cascade="all, delete-orphan"`)
• Added **bidirectional access** through `order.order_items` and `item.order` 
• Added **enhanced serialization** to include order_items in Order responses
• Added **optional query parameter** `-o` for basic order info only
• Added **nullable=False** constraint on OrderItem.order_id field
• Updated **Order.deserialize()** to handle nested order_items creation
• Updated **test factories** to respect foreign key constraints
• Updated **test cleanup** to handle foreign key dependencies

How to test:
```bash
flask db-create
make test
```
closed #69 