### PR TITLE
Adding field shipped_at to Order

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -7,6 +7,7 @@ All of the models are stored in this module
 import logging
 from typing import Any
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime, UTC
 
 logger = logging.getLogger("flask.app")
 
@@ -33,6 +34,7 @@ class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
     status = db.Column(db.String(16), nullable=False, default="placed")
+    shipped_at = db.Column(db.DateTime(timezone = True))
     # maybe store any promotions used on this order?
 
     def create(self):
@@ -42,6 +44,8 @@ class Order(db.Model):
         logger.info("Creating %s", self)
         self.id = None
         try:
+            if self.status == "shipped" and self.shipped_at is None:
+                self.shipped_at = datetime.now(UTC)
             db.session.add(self)
             db.session.commit()
         except Exception as e:
@@ -55,6 +59,8 @@ class Order(db.Model):
         """
         logger.info("Saving %s", self)
         try:
+            if self.status == "shipped" and self.shipped_at is None:
+                self.shipped_at = datetime.now(UTC)
             db.session.commit()
         except Exception as e:
             db.session.rollback()

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,6 +4,7 @@ Test Factory to make fake objects for testing
 
 import factory
 from service.models import Order, OrderItem
+from datetime import datetime, UTC
 
 STATUS_CHOICES = ["placed", "shipped", "returned", "canceled"]
 
@@ -19,6 +20,10 @@ class OrderFactory(factory.Factory):
     customer_id = factory.Sequence(lambda n: n)
     status = factory.Faker("random_element", elements=STATUS_CHOICES)
 
+    @factory.lazy_attribute
+    def shipped_at(self):
+        """Auto fill shipped_at only if the status is 'shipped' """
+        return datetime.now(UTC) if self.status == 'shipped' else None
 
 class OrderItemFactory(factory.Factory):
     """Creates fake order item"""


### PR DESCRIPTION
Made the following changes:

- Added ``shipped_at`` to ``Order`` model
- Added test case for shipped_at
- Added lazy decorator that fills a value for ``shipped_at`` when necessary

How to test:
``flask db-create`` after the changes to the model
``make test``