### PR TITLE
Adding created_at field to Order model

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -34,7 +34,7 @@ class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
     status = db.Column(db.String(16), nullable=False, default="placed")
-    created_at  = db.Column(db.DateTime(timezone=True), nullable=False)
+    created_at = db.Column(db.DateTime(timezone=True), nullable=False)
     # maybe store any promotions used on this order?
 
     def create(self):
@@ -79,10 +79,11 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id,
-                "customer_id": self.customer_id,
-                "status": self.status,
-                "created_at": self.created_at.isoformat(),
+        return {
+            "id": self.id,
+            "customer_id": self.customer_id,
+            "status": self.status,
+            "created_at": self.created_at.isoformat(),
         }
 
     def deserialize(self, data: dict[str, Any]):

--- a/service/models.py
+++ b/service/models.py
@@ -79,9 +79,9 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id, 
-                "customer_id": self.customer_id, 
-                "status": self.status, 
+        return {"id": self.id,
+                "customer_id": self.customer_id,
+                "status": self.status,
                 "created_at": self.created_at.isoformat(),
         }
 

--- a/service/models.py
+++ b/service/models.py
@@ -6,8 +6,8 @@ All of the models are stored in this module
 
 import logging
 from typing import Any
-from flask_sqlalchemy import SQLAlchemy
 from datetime import datetime, UTC
+from flask_sqlalchemy import SQLAlchemy
 
 logger = logging.getLogger("flask.app")
 

--- a/service/models.py
+++ b/service/models.py
@@ -7,6 +7,7 @@ All of the models are stored in this module
 import logging
 from typing import Any
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime, UTC
 
 logger = logging.getLogger("flask.app")
 
@@ -33,6 +34,7 @@ class Order(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     customer_id = db.Column(db.Integer)
     status = db.Column(db.String(16), nullable=False, default="placed")
+    created_at  = db.Column(db.DateTime(timezone=True), nullable=False)
     # maybe store any promotions used on this order?
 
     def create(self):
@@ -42,6 +44,9 @@ class Order(db.Model):
         logger.info("Creating %s", self)
         self.id = None
         try:
+            if self.created_at is None:
+                self.created_at = datetime.now(UTC)
+
             db.session.add(self)
             db.session.commit()
         except Exception as e:

--- a/service/models.py
+++ b/service/models.py
@@ -79,7 +79,11 @@ class Order(db.Model):
 
     def serialize(self) -> dict[str, Any]:
         """Serializes an order into a dictionary"""
-        return {"id": self.id, "customer_id": self.customer_id, "status": self.status}
+        return {"id": self.id, 
+                "customer_id": self.customer_id, 
+                "status": self.status, 
+                "created_at": self.created_at.isoformat(),
+        }
 
     def deserialize(self, data: dict[str, Any]):
         """
@@ -88,7 +92,7 @@ class Order(db.Model):
         try:
             self.customer_id = data["customer_id"]
             status = str(data.get("status", self.status or DEFAULT_STATUS)).lower()
-
+            self.created_at = data["created_at"]
             if status not in ALLOWED_STATUS:
                 raise DataValidationError(f"Invalid status '{status}'")
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -4,6 +4,7 @@ Test Factory to make fake objects for testing
 
 import factory
 from service.models import Order, OrderItem
+from datetime import datetime, UTC
 
 STATUS_CHOICES = ["placed", "shipped", "returned", "canceled"]
 
@@ -19,6 +20,9 @@ class OrderFactory(factory.Factory):
     customer_id = factory.Sequence(lambda n: n)
     status = factory.Faker("random_element", elements=STATUS_CHOICES)
 
+    @factory.lazy_attribute
+    def created_at(self):
+        return datetime.now(UTC)
 
 class OrderItemFactory(factory.Factory):
     """Creates fake order item"""

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,10 +1,10 @@
 """
 Test Factory to make fake objects for testing
 """
-
+from datetime import datetime, UTC
 import factory
 from service.models import Order, OrderItem
-from datetime import datetime, UTC
+
 
 STATUS_CHOICES = ["placed", "shipped", "returned", "canceled"]
 
@@ -22,6 +22,7 @@ class OrderFactory(factory.Factory):
 
     @factory.lazy_attribute
     def created_at(self):
+        """Fill out created_at value only when this is called"""
         return datetime.now(UTC)
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -24,6 +24,7 @@ class OrderFactory(factory.Factory):
     def created_at(self):
         return datetime.now(UTC)
 
+
 class OrderItemFactory(factory.Factory):
     """Creates fake order item"""
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -24,10 +24,11 @@ import os
 import logging
 from unittest import TestCase
 from unittest.mock import patch
+from datetime import datetime, UTC
 from wsgi import app
 from service.models import Order, OrderItem, DataValidationError, db
 from .factories import OrderFactory, OrderItemFactory
-from datetime import datetime, UTC
+
 
 DATABASE_URI = os.getenv(
     "DATABASE_URI", "postgresql+psycopg://postgres:postgres@localhost:5432/testdb"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -324,7 +324,7 @@ class TestOrderItem(TestCase):
     def test_created_at_set_on_create(self):
         """If an order is created, created_at is auto filled AFTER the order is created"""
         before = datetime.now(UTC)
-        order = Order(status= "placed")
+        order = Order(status="placed")
         order.create()
         after = datetime.now(UTC)
         found = Order.find(order.id)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -306,7 +306,7 @@ class TestOrderItem(TestCase):
         order.create()
 
         # simulate deserialization from API payload
-        order.deserialize({"customer_id": order.customer_id, "status": "canceled"})
+        order.deserialize({"customer_id": order.customer_id, "status": "canceled", "created_at": order.created_at})
         order.update()
 
         found = Order.find(order.id)


### PR DESCRIPTION
Made the following changes:

- Added ``created_at`` to ``Order`` model
- Added test case for created_at
- Added lazy decorator that fills a value for ``created_at`` when necessary

How to test:
``flask db-create`` after the changes to the model
``make test``