### PR TITLE
Add cancel BDD scenario (same as update with status change)

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -56,7 +56,7 @@ Feature: The Order service back-end
     
     Scenario: Cancel an Order
         When I visit the "Home Page"
-        And I select "Cancel" in the "operation-select" dropdown
+        And I select "Update" in the "operation-select" dropdown
         When I get the first order id from the results
         And I set the "order_id" to "{first_order_id}"
         And I select "Canceled" in the "order_status" dropdown

--- a/features/orders.feature
+++ b/features/orders.feature
@@ -53,3 +53,12 @@ Feature: The Order service back-end
         And I select "Unchanged" in the "order_status" dropdown
         And I press the "Apply" button
         Then I should see "successful" in the message
+    
+    Scenario: Cancel an Order
+        When I visit the "Home Page"
+        And I select "Cancel" in the "operation-select" dropdown
+        When I get the first order id from the results
+        And I set the "order_id" to "{first_order_id}"
+        And I select "Canceled" in the "order_status" dropdown
+        And I press the "Apply" button
+        Then I should see "successful" in the message


### PR DESCRIPTION
 **New test scenario**: Introduced a "Cancel an Order" scenario to verify that users can successfully update an order's status to "Canceled" using the dropdown and apply button.