### PR TITLE
UI/BDD Scenario - Delete Order

### DIFF
--- a/features/orders.feature
+++ b/features/orders.feature
@@ -66,3 +66,12 @@ Feature: The Order service back-end
         And the "orderItem_quantity" field should not be empty
         And the "order_status" field should not be empty
         And the "orderItem_id" field should not be empty
+
+    Scenario: Delete an existing Order using the Delete button
+        When I visit the "Home Page"
+        And I get the first order id from the results
+        And I select "Delete" in the "operation-select" dropdown
+        And I set the "order_id" to "{first_order_id}"
+        And I press the "Delete" button
+        Then I should see "Order deleted successfully" in the message
+        And I should not see "{first_order_id}" in the results

--- a/features/steps/web_steps.py
+++ b/features/steps/web_steps.py
@@ -83,7 +83,9 @@ def step_impl(context, element_name, text_string):
         var_name = text_string[1:-1]
         text_string = getattr(context, var_name)
     element_id = element_name.replace(" ", "_")
-    element = context.driver.find_element(By.ID, element_id)
+    element = WebDriverWait(context.driver, context.wait_seconds).until(
+        expected_conditions.element_to_be_clickable((By.ID, element_id))
+    )
     element.clear()
     element.send_keys(text_string)
 
@@ -196,6 +198,11 @@ def step_impl(context, text):
 @when('I press the "Retrieve" button')
 def step_impl(context):
     button = context.driver.find_element(By.ID, "retrieve-btn")
+    button.click()
+
+@when('I press the "Delete" button')
+def step_impl(context):
+    button = context.driver.find_element(By.ID, "delete-btn")
     button.click()
 
 @then('the "{element_name}" field should not be empty')

--- a/service/static/js/rest_api.js
+++ b/service/static/js/rest_api.js
@@ -61,6 +61,14 @@ $(function () {
             $("#product_id").prop("disabled", true);
             $("#orderItem_quantity").prop("disabled", true);
             $("#order_status").prop("disabled", true);
+        } else if (operation === "delete") {
+            // Only order_id is enabled for delete, others are disabled
+            $("#order_id").prop("disabled", false);
+            $("#orderItem_id").prop("disabled", true);
+            $("#customer_id").prop("disabled", true);
+            $("#product_id").prop("disabled", true);
+            $("#orderItem_quantity").prop("disabled", true);
+            $("#order_status").prop("disabled", true);
         } else {
             $("#order_id").prop("disabled", false);
             $("#orderItem_id").prop("disabled", false);
@@ -331,6 +339,32 @@ $(function () {
         ajax.done(function (res) {
             update_form_data(res);
             flash_message("Order retrieved successfully");
+        });
+        ajax.fail(function (res) {
+            flash_message(res.responseJSON.message);
+        });
+    });
+
+    // ****************************************
+    // Delete order by order_id when clicking the delete button next to order_id
+    // ****************************************
+    $("#delete-btn").click(function (e) {
+        e.preventDefault();
+        let order_id = $("#order_id").val();
+        if (!order_id) {
+            flash_message("Order ID is required for delete.");
+            return;
+        }
+        $("#flash_message").empty();
+        let ajax = $.ajax({
+            type: "DELETE",
+            url: `/orders/${order_id}`,
+        });
+        ajax.done(function () {
+            flash_message("Order deleted successfully");
+            clear_form_data();
+            // Refresh the results table to show the updated list
+            loadAllOrders();
         });
         ajax.fail(function (res) {
             flash_message(res.responseJSON.message);


### PR DESCRIPTION
### Feature Addition: Delete Order Functionality
* Added a new scenario in `features/orders.feature` to test deleting an order using the "Delete" button. The scenario includes steps to select an order, delete it, and verify its removal from the results.
* Implemented a new JavaScript function in `service/static/js/rest_api.js` to handle the delete operation. It validates the `order_id`, sends a DELETE request, and refreshes the results table upon success.
* Updated the JavaScript logic to enable only the `order_id` field when the "delete" operation is selected, disabling all other fields.

### Back-End Enhancements
* Modified the `features/steps/web_steps.py` step definition to use `WebDriverWait` for ensuring elements are clickable before interacting with them. This improves stability during automated testing.
* Added a new step definition in `features/steps/web_steps.py` to handle the action of pressing the "Delete" button.